### PR TITLE
Don't NRE when calling SkinManager.AddSkin during initialization

### DIFF
--- a/CustomKnight/Menu/BetterMenu.cs
+++ b/CustomKnight/Menu/BetterMenu.cs
@@ -45,7 +45,7 @@ namespace CustomKnight
         internal static void UpdateSkinList()
         {
             SkinManager.getSkinNames();
-            MenuRef.Find("SelectSkinOption").updateAfter((element) =>
+            MenuRef?.Find("SelectSkinOption").updateAfter((element) =>
             {
                 ((HorizontalOption)element).Values = getSkinNameArray();
             });


### PR DESCRIPTION
It's not currently possible to add an embedded skin during the `OnInit` phase because of an NRE on this line (MenuRef isn't initialized yet).  This makes it impossible for a previously-selected embedded skin to be loaded during initialization, since the only other event, `OnReady`, is never run when the default skin is pre-selected, making the embedded skin unselectable.