### PR TITLE
Ck3.5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build Mod
         run: dotnet build -c Release
       - name: Upload Mod
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: CustomKnightModlinks
           path: ./CustomKnight/bin/Release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,9 +25,7 @@ jobs:
           apiPath: HKManaged
           dependencyFilePath: ModDependencies.txt
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
-      - name: Setup ms-build
-        run: sudo apt-get install -y nuget mono-devel mono-xbuild
+        uses: actions/setup-dotnet@v3
       - name: Restore dependencies
         run: dotnet restore
       - name: Build Mod

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build Mod
         run: dotnet build -c Release
       - name: Upload Mod
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: CustomKnightModlinks
           path: ./CustomKnight/bin/Release

--- a/.github/workflows/pinned.yml
+++ b/.github/workflows/pinned.yml
@@ -25,9 +25,7 @@ jobs:
           apiPath: HKManaged
           dependencyFilePath: ModDependencies_pinned.txt
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
-      - name: Setup ms-build
-        run: sudo apt-get install -y nuget mono-devel mono-xbuild
+        uses: actions/setup-dotnet@v3
       - name: Restore dependencies
         run: dotnet restore
       - name: Build Mod

--- a/.github/workflows/pinned.yml
+++ b/.github/workflows/pinned.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build Mod
         run: dotnet build -c Release
       - name: Upload Mod
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: CustomKnightPinned
           path: ./CustomKnight/bin/Release

--- a/.github/workflows/pinned.yml
+++ b/.github/workflows/pinned.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build Mod
         run: dotnet build -c Release
       - name: Upload Mod
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: CustomKnightPinned
           path: ./CustomKnight/bin/Release

--- a/CustomKnight/CustomKnight.csproj
+++ b/CustomKnight/CustomKnight.csproj
@@ -3,7 +3,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>CustomKnight</RootNamespace>
     <AssemblyName>CustomKnight</AssemblyName>
-    <AssemblyVersion>3.1.0</AssemblyVersion>
+    <AssemblyVersion>3.5.0</AssemblyVersion>
     <TargetFramework>net472</TargetFramework>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>

--- a/CustomKnight/GlobalUsings.cs
+++ b/CustomKnight/GlobalUsings.cs
@@ -1,8 +1,8 @@
-global using HutongGames.PlayMaker.Actions;
-global using Modding;
-global using Satchel;
 global using System;
 global using System.Collections;
 global using System.Collections.Generic;
+global using HutongGames.PlayMaker.Actions;
+global using Modding;
+global using Satchel;
 global using UnityEngine;
 global using UnityEngine.SceneManagement;

--- a/CustomKnight/Menu/AuthorsMenu.cs
+++ b/CustomKnight/Menu/AuthorsMenu.cs
@@ -11,6 +11,12 @@ namespace CustomKnight
         {
             var menu = new Menu("Author Tools", new Element[]{
                new MenuButton("Dump","Dumps the sprites that Swapper supports (Expect lag)",(_)=>ToggleDumping(),Id:"DumpButton"),
+               Blueprints.HorizontalBoolOption(
+                    "Disable directory swap","(restart required)",
+                    (v) => {
+                        CustomKnight.GlobalSettings.DisableDirectorySwaps = v;
+                    },
+                    () => CustomKnight.GlobalSettings.DisableDirectorySwaps),
             });
 
             return menu;

--- a/CustomKnight/Menu/AuthorsMenu.cs
+++ b/CustomKnight/Menu/AuthorsMenu.cs
@@ -10,12 +10,6 @@ namespace CustomKnight
         internal static Menu PrepareMenu()
         {
             var menu = new Menu("Author Tools", new Element[]{
-            new HorizontalOption(
-                    "Dump Style", "Choose dump style, Names.Json is Recommended, Directory is Faster",
-                    new string[] { "Names.Json", "Directory" },
-                    (setting) => { CustomKnight.GlobalSettings.DumpOldSwaps = setting == 1; },
-                    () => CustomKnight.GlobalSettings.DumpOldSwaps ? 1 : 0,
-                    Id:"SelectDumpOption"),
                new MenuButton("Dump","Dumps the sprites that Swapper supports (Expect lag)",(_)=>ToggleDumping(),Id:"DumpButton"),
             });
 

--- a/CustomKnight/Menu/BetterMenu.cs
+++ b/CustomKnight/Menu/BetterMenu.cs
@@ -1,6 +1,6 @@
+using System.Linq;
 using CustomKnight.NewUI;
 using Satchel.BetterMenus;
-using System.Linq;
 
 namespace CustomKnight
 {

--- a/CustomKnight/NewUI/UIController.cs
+++ b/CustomKnight/NewUI/UIController.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using UnityEngine.UI;
+﻿using UnityEngine.UI;
 
 namespace CustomKnight.NewUI
 {

--- a/CustomKnight/NewUI/UIController.cs
+++ b/CustomKnight/NewUI/UIController.cs
@@ -215,6 +215,14 @@ namespace CustomKnight.NewUI
 
             var title = new UIText(content, "Title", "Skin List");
             title.text.fontSize = 25;
+            title.textTransform.sizeDelta = new Vector2(168f, 25f);
+
+            var keybind = CustomKnight.GlobalSettings.Keybinds.OpenSkinList.GetKeyOrMouseBinding().Key;
+            var helpText = new UIText(content, "helpText", $"Press {keybind} to toggle menu");
+            helpText.text.fontSize = 10;
+            helpText.text.alignment = TextAnchor.UpperCenter;
+            helpText.textTransform.sizeDelta = new Vector2(168f, 50f);
+
             var favSkins = new List<string>();
             favSkins.AddRange(CustomKnight.GlobalSettings.FavoriteSkins);
             favSkins.AddRange(CustomKnight.GlobalSettings.RecentSkins);

--- a/CustomKnight/NewUI/UIText.cs
+++ b/CustomKnight/NewUI/UIText.cs
@@ -9,6 +9,7 @@ namespace CustomKnight.NewUI
         public GameObject parent;
         public GameObject self;
         public Text text;
+        public RectTransform textTransform;
         public UIText(GameObject parent, string name, string value)
         {
             this.name = name;
@@ -22,7 +23,7 @@ namespace CustomKnight.NewUI
             self = new GameObject(name);
             self.transform.SetParent(parent.transform, false);
             self.AddComponent<CanvasRenderer>();
-            RectTransform textTransform = self.AddComponent<RectTransform>();
+            textTransform = self.AddComponent<RectTransform>();
             text = self.AddComponent<Text>();
             text.text = this.value;
             text.fontStyle = FontStyle.Bold;

--- a/CustomKnight/Settings.cs
+++ b/CustomKnight/Settings.cs
@@ -74,6 +74,11 @@ namespace CustomKnight
         public bool EnableParticleSwap { get; set; } = false;
 
         /// <summary>
+        /// Option to disable loading directory swaps, makes it possible to debug skins incompatible with names.json
+        /// </summary>
+        public bool DisableDirectorySwaps { get; set; } = false;
+
+        /// <summary>
         /// Used to indicate to generate default skin on next restart
         /// </summary>
         public bool GenerateDefaultSkin { get; set; } = true;

--- a/CustomKnight/Settings.cs
+++ b/CustomKnight/Settings.cs
@@ -71,7 +71,7 @@ namespace CustomKnight
         /// <summary>
         /// Option to enable swapping particles (only active when swap is enabled)
         /// </summary>
-        public bool EnableParticleSwap { get; set; } = false;
+        public bool EnableParticleSwap { get; set; } = true;
 
         /// <summary>
         /// Option to disable loading directory swaps, makes it possible to debug skins incompatible with names.json

--- a/CustomKnight/Settings.cs
+++ b/CustomKnight/Settings.cs
@@ -57,10 +57,6 @@ namespace CustomKnight
         [JsonProperty]
         private Dictionary<int, string> saveSkins = new Dictionary<int, string>() { { 0, SkinManager.DEFAULT_SKIN }, { 1, SkinManager.DEFAULT_SKIN }, { 2, SkinManager.DEFAULT_SKIN }, { 3, SkinManager.DEFAULT_SKIN } };
 
-        /// <summary>
-        /// Option to dump swaps in the old directory style
-        /// </summary>
-        public bool DumpOldSwaps { get; set; } = false;
 
         /// <summary>
         /// Option to enable the new Pause Menu

--- a/CustomKnight/Skin/Base/SkinManager.cs
+++ b/CustomKnight/Skin/Base/SkinManager.cs
@@ -1,5 +1,6 @@
 using System.Drawing;
 using System.IO;
+using CustomKnight.Skin.Base.SkinableItems;
 using static Satchel.IoUtils;
 
 namespace CustomKnight
@@ -191,6 +192,8 @@ namespace CustomKnight
             {BrummShield.NAME,new BrummShield() },
             {FlowerBreak.NAME,new FlowerBreak() },
             {Salubra.NAME,new Salubra() },
+            {FlameUI.FRONT,new FlameUI(FlameUI.FRONT) },
+            {FlameUI.BACK,new FlameUI(FlameUI.BACK) },
            // {"PinsScarab", new Pins()}
         };
         /// <summary>

--- a/CustomKnight/Skin/Base/SkinManager.cs
+++ b/CustomKnight/Skin/Base/SkinManager.cs
@@ -1,4 +1,3 @@
-using System.Drawing;
 using System.IO;
 using CustomKnight.Skin.Base.SkinableItems;
 using static Satchel.IoUtils;
@@ -418,7 +417,8 @@ namespace CustomKnight
                 CustomKnight.GlobalSettings.DefaultSkin = id;
                 CustomKnight.SaveSettings.DefaultSkin = id;
                 GlobalModSettings.SetSkinForProfileID(GameManager.instance.profileID, id);
-            };
+            }
+            ;
             if (CurrentSkin?.GetId() == Skin.GetId()) { return; }
             CurrentSkin = Skin;
             CustomKnight.GlobalSettings.AddRecentSkin(id);

--- a/CustomKnight/Skin/Base/SkinableItems/Charm.cs
+++ b/CustomKnight/Skin/Base/SkinableItems/Charm.cs
@@ -1,9 +1,4 @@
-using System.Linq;
-using System.Security.Policy;
 using HutongGames.PlayMaker;
-using Satchel;
-using Satchel.Futils;
-using UnityEngine;
 
 namespace CustomKnight
 {
@@ -31,7 +26,7 @@ namespace CustomKnight
         private void CustomKnight_OnInit(object sender, EventArgs e)
         {
             CustomKnight.Instance.LogDebug($"Hook {name}");
-            On.CharmDisplay.Start += CharmDisplay_Start; 
+            On.CharmDisplay.Start += CharmDisplay_Start;
             ModHooks.LanguageGetHook += ModHooks_LanguageGetHook;
 
         }
@@ -165,7 +160,7 @@ namespace CustomKnight
         public override void ApplySprite(Sprite sprite)
         {
             PlayMakerFSM charmShowIfCollected;
-            PlayMakerFSM updateSprite  = GameCameras.instance.hudCamera.gameObject.FindGameObjectInChildren("Detail Sprite").LocateMyFSM("Update Sprite");
+            PlayMakerFSM updateSprite = GameCameras.instance.hudCamera.gameObject.FindGameObjectInChildren("Detail Sprite").LocateMyFSM("Update Sprite");
             currentSprite = sprite;
             switch (charmName)
             {
@@ -259,7 +254,7 @@ namespace CustomKnight
                     clone.Value = sprite;
                     charmShowIfCollected.GetAction<SetSpriteRendererSprite>("Check", 7).sprite = clone;
                     CharmIconList.Instance.spriteList[charmNum] = sprite;
-                    break; 
+                    break;
                 default:
                     CharmIconList.Instance.spriteList[charmNum] = sprite;
                     break;

--- a/CustomKnight/Skin/Base/SkinableItems/Charm.cs
+++ b/CustomKnight/Skin/Base/SkinableItems/Charm.cs
@@ -1,13 +1,58 @@
+using System.Security.Policy;
+using Satchel;
+using UnityEngine;
+
 namespace CustomKnight
 {
     internal class Charm : Skinable_Sprite
     {
         public int charmNum;
         public string charmName;
+        private Sprite currentSprite;
         public Charm(string charmName, int charmNum) : base("Charms/" + charmName)
         {
             this.charmName = charmName;
             this.charmNum = charmNum;
+            CustomKnight.OnInit += CustomKnight_OnInit;
+            CustomKnight.OnUnload += CustomKnight_OnUnload;
+        }
+
+        private void CustomKnight_OnUnload(object sender, EventArgs e)
+        {
+            CustomKnight.Instance.LogDebug($"UnHook {name}");
+            On.CharmDisplay.Start -= CharmDisplay_Start;
+        }
+
+        private void CustomKnight_OnInit(object sender, EventArgs e)
+        {
+            CustomKnight.Instance.LogDebug($"Hook {name}");
+            On.CharmDisplay.Start += CharmDisplay_Start;
+        }
+
+        private void CharmDisplay_Start(On.CharmDisplay.orig_Start orig, CharmDisplay charmDisplay)
+        {
+            if (currentSprite != null)
+            {
+                switch (charmName)
+                {
+                    case "Charm_23_Broken":
+                        charmDisplay.brokenGlassHP = currentSprite;
+                        break;
+                    case "Charm_24_Broken":
+                        charmDisplay.brokenGlassGeo = currentSprite;
+                        break;
+                    case "Charm_25_Broken":
+                        charmDisplay.brokenGlassAttack = currentSprite;
+                        break;
+                    case "Charm_36_Full":
+                        charmDisplay.whiteCharm = currentSprite;
+                        break;
+                    case "Charm_36_Black":
+                        charmDisplay.blackCharm = currentSprite;
+                        break;
+                }
+            }
+            orig(charmDisplay);
         }
 
         public override void SaveDefaultTexture()
@@ -101,6 +146,8 @@ namespace CustomKnight
         public override void ApplySprite(Sprite sprite)
         {
             PlayMakerFSM charmShowIfCollected;
+            PlayMakerFSM updateSprite  = GameCameras.instance.hudCamera.gameObject.FindGameObjectInChildren("Detail Sprite").LocateMyFSM("Update Sprite");
+            currentSprite = sprite;
             switch (charmName)
             {
                 case "Charm_23_Fragile":
@@ -110,6 +157,7 @@ namespace CustomKnight
                 case "Charm_23_Broken":
                     charmShowIfCollected = GameCameras.instance.hudCamera.gameObject.FindGameObjectInChildren(charmNum.ToString()).LocateMyFSM("charm_show_if_collected");
                     charmShowIfCollected.GetAction<SetSpriteRendererSprite>("Glass HP", 2).sprite.Value = sprite;
+                    updateSprite.GetAction<SetSpriteRendererSprite>("Glass HP", 2).sprite.Value = sprite;
                     break;
 
                 case "Charm_23_Unbreakable":
@@ -122,6 +170,7 @@ namespace CustomKnight
                 case "Charm_24_Broken":
                     charmShowIfCollected = GameCameras.instance.hudCamera.gameObject.FindGameObjectInChildren(charmNum.ToString()).LocateMyFSM("charm_show_if_collected");
                     charmShowIfCollected.GetAction<SetSpriteRendererSprite>("Glass Geo", 2).sprite.Value = sprite;
+                    updateSprite.GetAction<SetSpriteRendererSprite>("Glass Geo", 2).sprite.Value = sprite;
                     break;
 
                 case "Charm_24_Unbreakable":
@@ -135,6 +184,7 @@ namespace CustomKnight
                 case "Charm_25_Broken":
                     charmShowIfCollected = GameCameras.instance.hudCamera.gameObject.FindGameObjectInChildren(charmNum.ToString()).LocateMyFSM("charm_show_if_collected");
                     charmShowIfCollected.GetAction<SetSpriteRendererSprite>("Glass Attack", 2).sprite.Value = sprite;
+                    updateSprite.GetAction<SetSpriteRendererSprite>("Glass Attack", 2).sprite.Value = sprite;
                     break;
 
                 case "Charm_25_Unbreakable":
@@ -144,21 +194,25 @@ namespace CustomKnight
                 case "Charm_36_Left":
                     charmShowIfCollected = GameCameras.instance.hudCamera.gameObject.FindGameObjectInChildren(charmNum.ToString()).LocateMyFSM("charm_show_if_collected");
                     charmShowIfCollected.GetAction<SetSpriteRendererSprite>("R Queen", 0).sprite.Value = sprite;
+                    updateSprite.GetAction<SetSpriteRendererSprite>("R Queen", 0).sprite.Value = sprite;
                     break;
 
                 case "Charm_36_Right":
                     charmShowIfCollected = GameCameras.instance.hudCamera.gameObject.FindGameObjectInChildren(charmNum.ToString()).LocateMyFSM("charm_show_if_collected");
                     charmShowIfCollected.GetAction<SetSpriteRendererSprite>("R King", 0).sprite.Value = sprite;
+                    updateSprite.GetAction<SetSpriteRendererSprite>("R King", 0).sprite.Value = sprite;
                     break;
 
                 case "Charm_36_Full":
                     charmShowIfCollected = GameCameras.instance.hudCamera.gameObject.FindGameObjectInChildren(charmNum.ToString()).LocateMyFSM("charm_show_if_collected");
                     charmShowIfCollected.GetAction<SetSpriteRendererSprite>("R Final", 0).sprite.Value = sprite;
+                    updateSprite.GetAction<SetSpriteRendererSprite>("R Final", 0).sprite.Value = sprite;
                     break;
 
                 case "Charm_36_Black":
                     charmShowIfCollected = GameCameras.instance.hudCamera.gameObject.FindGameObjectInChildren(charmNum.ToString()).LocateMyFSM("charm_show_if_collected");
                     charmShowIfCollected.GetAction<SetSpriteRendererSprite>("R Shade", 0).sprite.Value = sprite;
+                    updateSprite.GetAction<SetSpriteRendererSprite>("R Shade", 0).sprite.Value = sprite;
                     break;
 
                 case "Charm_40_1":

--- a/CustomKnight/Skin/Base/SkinableItems/Charm.cs
+++ b/CustomKnight/Skin/Base/SkinableItems/Charm.cs
@@ -1,5 +1,8 @@
+using System.Linq;
 using System.Security.Policy;
+using HutongGames.PlayMaker;
 using Satchel;
+using Satchel.Futils;
 using UnityEngine;
 
 namespace CustomKnight
@@ -21,14 +24,30 @@ namespace CustomKnight
         {
             CustomKnight.Instance.LogDebug($"UnHook {name}");
             On.CharmDisplay.Start -= CharmDisplay_Start;
+            ModHooks.LanguageGetHook -= ModHooks_LanguageGetHook;
         }
+
 
         private void CustomKnight_OnInit(object sender, EventArgs e)
         {
             CustomKnight.Instance.LogDebug($"Hook {name}");
-            On.CharmDisplay.Start += CharmDisplay_Start;
+            On.CharmDisplay.Start += CharmDisplay_Start; 
+            ModHooks.LanguageGetHook += ModHooks_LanguageGetHook;
+
         }
 
+        private string ModHooks_LanguageGetHook(string key, string sheetTitle, string orig)
+        {
+            if (sheetTitle == "UI" && key == "CHARM_NAME_36")
+            {
+                return "Silksong Unlocker";
+            }
+            if (sheetTitle == "UI" && key == "CHARM_DESC_36")
+            {
+                return "Custom Knight Says Hi!";
+            }
+            return orig;
+        }
         private void CharmDisplay_Start(On.CharmDisplay.orig_Start orig, CharmDisplay charmDisplay)
         {
             if (currentSprite != null)
@@ -234,7 +253,15 @@ namespace CustomKnight
                 case "Charm_40_5":
                     CharmIconList.Instance.nymmCharm = sprite;
                     break;
+                case "Charm_0":
+                    charmShowIfCollected = GameCameras.instance.hudCamera.gameObject.FindGameObjectInChildren("36").LocateMyFSM("charm_show_if_collected");
+                    var clone = new FsmObject();
+                    clone.Value = sprite;
+                    charmShowIfCollected.GetAction<SetSpriteRendererSprite>("Check", 7).sprite = clone;
+                    updateSprite.GetAction<SetSpriteRendererSprite>("Update", 3).sprite = clone;
 
+                    CharmIconList.Instance.spriteList[charmNum] = sprite;
+                    break; 
                 default:
                     CharmIconList.Instance.spriteList[charmNum] = sprite;
                     break;

--- a/CustomKnight/Skin/Base/SkinableItems/Charm.cs
+++ b/CustomKnight/Skin/Base/SkinableItems/Charm.cs
@@ -258,8 +258,6 @@ namespace CustomKnight
                     var clone = new FsmObject();
                     clone.Value = sprite;
                     charmShowIfCollected.GetAction<SetSpriteRendererSprite>("Check", 7).sprite = clone;
-                    updateSprite.GetAction<SetSpriteRendererSprite>("Update", 3).sprite = clone;
-
                     CharmIconList.Instance.spriteList[charmNum] = sprite;
                     break; 
                 default:

--- a/CustomKnight/Skin/Base/SkinableItems/FlameUI.cs
+++ b/CustomKnight/Skin/Base/SkinableItems/FlameUI.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace CustomKnight.Skin.Base.SkinableItems
+﻿namespace CustomKnight.Skin.Base.SkinableItems
 {
     class FlameUI : Skinable_Sprite
     {

--- a/CustomKnight/Skin/Base/SkinableItems/FlameUI.cs
+++ b/CustomKnight/Skin/Base/SkinableItems/FlameUI.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CustomKnight.Skin.Base.SkinableItems
+{
+    class FlameUI : Skinable_Sprite
+    {
+        public const string FRONT = "front";
+        public const string BACK = "back";
+
+        private string flameType;
+
+        public FlameUI(string flameType) : base("Charms/" + flameType)
+        {
+            this.flameType = flameType;
+        }
+
+        public override void ApplySprite(Sprite sprite)
+        {
+            PlayMakerFSM FlameUIFsm = GameCameras.instance.hudCamera.gameObject.FindGameObjectInChildren("Grimm Flame UI").LocateMyFSM("Control");
+            switch (flameType)
+            {
+                case FRONT:
+                    FlameUIFsm.GetAction<SetSpriteRendererSprite>("S1 F 1", 0).sprite.Value = sprite;
+                    FlameUIFsm.GetAction<SetSpriteRendererSprite>("S1 F 2", 0).sprite.Value = sprite;
+                    FlameUIFsm.GetAction<SetSpriteRendererSprite>("S1 F 2", 1).sprite.Value = sprite;
+                    FlameUIFsm.GetAction<SetSpriteRendererSprite>("S1 F 3", 0).sprite.Value = sprite;
+                    FlameUIFsm.GetAction<SetSpriteRendererSprite>("S1 F 3", 1).sprite.Value = sprite;
+                    FlameUIFsm.GetAction<SetSpriteRendererSprite>("S1 F 3", 2).sprite.Value = sprite;
+                    break;
+                case BACK:
+                    FlameUIFsm.GetAction<SetSpriteRendererSprite>("None", 0).sprite.Value = sprite;
+                    FlameUIFsm.GetAction<SetSpriteRendererSprite>("None", 1).sprite.Value = sprite;
+                    FlameUIFsm.GetAction<SetSpriteRendererSprite>("None", 2).sprite.Value = sprite;
+                    FlameUIFsm.GetAction<SetSpriteRendererSprite>("S1 F 1", 1).sprite.Value = sprite;
+                    FlameUIFsm.GetAction<SetSpriteRendererSprite>("S1 F 1", 2).sprite.Value = sprite;
+                    FlameUIFsm.GetAction<SetSpriteRendererSprite>("S1 F 2", 2).sprite.Value = sprite;
+                    break;
+            }
+        }
+
+        public override void SaveDefaultTexture()
+        {
+            PlayMakerFSM FlameUIFsm = GameCameras.instance.hudCamera.gameObject.FindGameObjectInChildren("Grimm Flame UI").LocateMyFSM("Control");
+            switch (flameType)
+            {
+                case FRONT:
+                    ckTex.defaultSprite = FlameUIFsm.GetAction<SetSpriteRendererSprite>("S1 F 1", 0).sprite.Value as Sprite;
+                    break;
+                case BACK:
+                    ckTex.defaultSprite = FlameUIFsm.GetAction<SetSpriteRendererSprite>("S1 F 1", 1).sprite.Value as Sprite;
+                    break;
+            }
+        }
+    }
+}

--- a/CustomKnight/Skin/Base/SkinableItems/Minions/Salubra.cs
+++ b/CustomKnight/Skin/Base/SkinableItems/Minions/Salubra.cs
@@ -18,11 +18,7 @@ namespace CustomKnight
             var behaviour = finalGo.GetAddComponent<SpriteRendererMaterialPropertyBlock>();
             if (tex != null)
             {
-                MaterialPropertyBlock block = new MaterialPropertyBlock();
-#pragma warning disable CS0618 // Type or member is obsolete
-                block.AddTexture("_MainTex", tex);
-#pragma warning restore CS0618 // Type or member is obsolete
-                behaviour.mpb = block;
+                behaviour.SetDefault(tex);
                 behaviour.enabled = true;
             }
             else

--- a/CustomKnight/Skin/Cinematics/CinematicsManager.cs
+++ b/CustomKnight/Skin/Cinematics/CinematicsManager.cs
@@ -1,5 +1,5 @@
-using CustomKnight.Skin.Cinematics;
 using System.IO;
+using CustomKnight.Skin.Cinematics;
 using UnityEngine.Video;
 using static Satchel.IoUtils;
 /*

--- a/CustomKnight/Skin/Settings/SettingsLoader.cs
+++ b/CustomKnight/Skin/Settings/SettingsLoader.cs
@@ -1,5 +1,5 @@
-﻿using Newtonsoft.Json;
-using System.IO;
+﻿using System.IO;
+using Newtonsoft.Json;
 
 namespace CustomKnight
 {

--- a/CustomKnight/Skin/Swapper/DumpAnimationBehavior.cs
+++ b/CustomKnight/Skin/Swapper/DumpAnimationBehavior.cs
@@ -30,7 +30,7 @@ namespace CustomKnight.Skin.Swapper
             if (!sprites.ContainsKey(sr.sprite.name)) {
                 CustomKnight.Instance.Log($"[OnWillRenderObject] Animated object:{name}:sprite:{sr.sprite.name}");
                 CustomKnight.dumpManager.detected += 1;
-                var tex = TextureUtils.duplicateTexture(sr.sprite.texture);
+                var tex = SpriteUtils.ExtractTextureFromSprite(sr.sprite);// TextureUtils.duplicateTexture(sr.sprite.texture);
                 CustomKnight.dumpManager.SaveTextureDump(gameObject.scene,Path.Combine("dndy_spr_anim", sr.sprite.name), tex);
                 CustomKnight.dumpManager.done += 1;
                 sprites[sr.sprite.name] = sr.sprite;

--- a/CustomKnight/Skin/Swapper/DumpAnimationBehavior.cs
+++ b/CustomKnight/Skin/Swapper/DumpAnimationBehavior.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -30,7 +31,7 @@ namespace CustomKnight.Skin.Swapper
                 CustomKnight.Instance.Log($"[OnWillRenderObject] Animated object:{name}:sprite:{sr.sprite.name}");
                 CustomKnight.dumpManager.detected += 1;
                 var tex = TextureUtils.duplicateTexture(sr.sprite.texture);
-                CustomKnight.dumpManager.SaveTextureDump(gameObject.scene,sr.sprite.name, tex);
+                CustomKnight.dumpManager.SaveTextureDump(gameObject.scene,Path.Combine("dndy_spr_anim", sr.sprite.name), tex);
                 CustomKnight.dumpManager.done += 1;
                 sprites[sr.sprite.name] = sr.sprite;
                 GameObject.Destroy(tex);

--- a/CustomKnight/Skin/Swapper/DumpAnimationBehavior.cs
+++ b/CustomKnight/Skin/Swapper/DumpAnimationBehavior.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CustomKnight.Skin.Swapper
+{
+    /// <summary>
+    /// Class that allows dumping tricky animated sprites
+    /// </summary>
+    public class DumpAnimationBehavior : MonoBehaviour
+    {
+
+        private SpriteRenderer sr;
+
+        /// <summary>
+        /// Dictionary holding sprite name to Sprite
+        /// </summary>
+        public Dictionary<String, Sprite> sprites = new Dictionary<String, Sprite>();
+
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+        public void OnWillRenderObject()
+        {
+            if (!sprites.ContainsKey(sr.sprite.name)) {
+                CustomKnight.Instance.Log($"[OnWillRenderObject] Animated object:{name}:sprite:{sr.sprite.name}");
+                CustomKnight.dumpManager.detected += 1;
+                var tex = TextureUtils.duplicateTexture(sr.sprite.texture);
+                CustomKnight.dumpManager.SaveTextureDump(gameObject.scene,sr.sprite.name, tex);
+                CustomKnight.dumpManager.done += 1;
+                sprites[sr.sprite.name] = sr.sprite;
+                GameObject.Destroy(tex);
+            }
+        }
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
+
+
+    }
+
+
+
+}

--- a/CustomKnight/Skin/Swapper/DumpAnimationBehavior.cs
+++ b/CustomKnight/Skin/Swapper/DumpAnimationBehavior.cs
@@ -22,6 +22,10 @@ namespace CustomKnight.Skin.Swapper
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
         public void OnWillRenderObject()
         {
+            if (sr == null)
+            {
+                sr = GetComponent<SpriteRenderer>();
+            }
             if (!sprites.ContainsKey(sr.sprite.name)) {
                 CustomKnight.Instance.Log($"[OnWillRenderObject] Animated object:{name}:sprite:{sr.sprite.name}");
                 CustomKnight.dumpManager.detected += 1;

--- a/CustomKnight/Skin/Swapper/DumpAnimationBehavior.cs
+++ b/CustomKnight/Skin/Swapper/DumpAnimationBehavior.cs
@@ -31,7 +31,7 @@ namespace CustomKnight.Skin.Swapper
                 CustomKnight.Instance.Log($"[OnWillRenderObject] Animated object:{name}:sprite:{sr.sprite.name}");
                 CustomKnight.dumpManager.detected += 1;
                 var tex = SpriteUtils.ExtractTextureFromSprite(sr.sprite);// TextureUtils.duplicateTexture(sr.sprite.texture);
-                CustomKnight.dumpManager.SaveTextureDump(gameObject.scene,Path.Combine("dndy_spr_anim", sr.sprite.name), tex);
+                CustomKnight.dumpManager.SaveTextureDump(gameObject.scene,Path.Combine("ck_spr_anim", sr.sprite.name), tex);
                 CustomKnight.dumpManager.done += 1;
                 sprites[sr.sprite.name] = sr.sprite;
                 GameObject.Destroy(tex);

--- a/CustomKnight/Skin/Swapper/DumpAnimationBehavior.cs
+++ b/CustomKnight/Skin/Swapper/DumpAnimationBehavior.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.IO;
 
 namespace CustomKnight.Skin.Swapper
 {
@@ -27,11 +22,12 @@ namespace CustomKnight.Skin.Swapper
             {
                 sr = GetComponent<SpriteRenderer>();
             }
-            if (!sprites.ContainsKey(sr.sprite.name)) {
+            if (!sprites.ContainsKey(sr.sprite.name))
+            {
                 CustomKnight.Instance.Log($"[OnWillRenderObject] Animated object:{name}:sprite:{sr.sprite.name}");
                 CustomKnight.dumpManager.detected += 1;
                 var tex = SpriteUtils.ExtractTextureFromSprite(sr.sprite);// TextureUtils.duplicateTexture(sr.sprite.texture);
-                CustomKnight.dumpManager.SaveTextureDump(gameObject.scene,Path.Combine("ck_spr_anim", sr.sprite.name), tex);
+                CustomKnight.dumpManager.SaveTextureDump(gameObject.scene, Path.Combine("ck_spr_anim", sr.sprite.name), tex);
                 CustomKnight.dumpManager.done += 1;
                 sprites[sr.sprite.name] = sr.sprite;
                 GameObject.Destroy(tex);

--- a/CustomKnight/Skin/Swapper/DumpManager.cs
+++ b/CustomKnight/Skin/Swapper/DumpManager.cs
@@ -1,8 +1,7 @@
-using CustomKnight.Canvas;
-using CustomKnight.Skin.Swapper;
 using System.IO;
 using System.Linq;
-using UnityEngine.SceneManagement;
+using CustomKnight.Canvas;
+using CustomKnight.Skin.Swapper;
 using static Satchel.GameObjectUtils;
 using static Satchel.IoUtils;
 
@@ -193,7 +192,7 @@ namespace CustomKnight
             }
         }
 
-        internal bool ShouldSkipDumping(string sceneName,string goPath)
+        internal bool ShouldSkipDumping(string sceneName, string goPath)
         {
             if (ObjectNameResolver.Contains(sceneName, goPath))
             {

--- a/CustomKnight/Skin/Swapper/DumpManager.cs
+++ b/CustomKnight/Skin/Swapper/DumpManager.cs
@@ -146,10 +146,11 @@ namespace CustomKnight
                 {
                     var tex = TextureUtils.duplicateTexture(sr.sprite.texture);
                     var hash = tex.getHash();
-                    //MaterialProcessed[crc] = hash;
+                    MaterialProcessed[crc] = hash;
                     ObjectNameResolver.Add(scene.name, goPath, hash);
                     SaveTextureDump(scene, hash, tex);
                     GameObject.Destroy(tex);
+                    go.AddComponent<DumpAnimationBehavior>();
                 }
                 else
                 {

--- a/CustomKnight/Skin/Swapper/DumpManager.cs
+++ b/CustomKnight/Skin/Swapper/DumpManager.cs
@@ -2,6 +2,7 @@ using CustomKnight.Canvas;
 using CustomKnight.Skin.Swapper;
 using System.IO;
 using System.Linq;
+using UnityEngine.SceneManagement;
 using static Satchel.GameObjectUtils;
 using static Satchel.IoUtils;
 
@@ -136,37 +137,29 @@ namespace CustomKnight
                 {
                     return; // dont dump sprites from DontDestroyOnLoad
                 }
-                if (!CustomKnight.GlobalSettings.DumpOldSwaps)
-                {   // New style dumps will save sprites with hash mode for names.json
+                // New style dumps will save sprites with hash mode for names.json
+                if (ShouldSkipDumping(scene.name, goPath))
+                {
+                    return;
+                }
+                if (anim != null || SpecialCases.ChildSpriteAnimatedByParent(baseName))
+                {
+                    var tex = TextureUtils.duplicateTexture(sr.sprite.texture);
+                    var hash = tex.getHash();
+                    //MaterialProcessed[crc] = hash;
+                    ObjectNameResolver.Add(scene.name, goPath, hash);
+                    SaveTextureDump(scene, hash, tex);
+                    GameObject.Destroy(tex);
+                }
+                else
+                {
                     var tex = SpriteUtils.ExtractTextureFromSprite(sr.sprite);
                     var hash = tex.getHash();
                     MaterialProcessed[crc] = hash;
                     ObjectNameResolver.Add(scene.name, goPath, hash);
                     SaveTextureDump(scene, hash, tex);
                     GameObject.Destroy(tex);
-                    if (anim != null || SpecialCases.ChildSpriteAnimatedByParent(baseName))
-                    {
-                        ObjectNameResolver.Add(scene.name, goPath, hash);
-                        SaveTextureDump(scene, hash, tex);
-                    }
                 }
-                else
-                {   // old style dump will dump with directory structure
-                    if (anim != null || SpecialCases.ChildSpriteAnimatedByParent(baseName))
-                    {
-                        // remove the animation component
-                        //GameObject.Destroy(anim);
-                        //go.AddComponent<Animator>();
-                        var tex1 = sr.sprite.texture;
-                        if (CustomKnight.GlobalSettings.DumpOldSwaps)
-                        {
-                            SaveTextureDump(scene, baseName, tex1);
-                        }
-                        return;
-                    }
-                    SaveSpriteDump(scene, baseName, sr.sprite);
-                }
-                return;
             }
             if (tk2ds != null)
             {
@@ -177,45 +170,41 @@ namespace CustomKnight
                 {
                     return;
                 }
-                if (!CustomKnight.GlobalSettings.DumpOldSwaps)
+                //New style dumps will save textures with hash mode for names.json
+                if (!isMaterialUnprocessed)
                 {
-                    //New style dumps will save textures with hash mode for names.json
-                    if (!isMaterialUnprocessed)
-                    {
-                        return;
-                    }
-                    var dupe = TextureUtils.duplicateTexture(tex);
-                    var hash = HashWithCache.getTk2dSpriteHash(tk2ds);
-                    MaterialProcessed[crc] = hash;
-                    ObjectNameResolver.Add(scene.name, goPath, hash);
-                    if (scene.name != "DontDestroyOnLoad" || SpecialCases.AllowedDontDestroyOnLoad(goPath))
+                    return;
+                }
+                var dupe = TextureUtils.duplicateTexture(tex);
+                var hash = HashWithCache.getTk2dSpriteHash(tk2ds);
+                MaterialProcessed[crc] = hash;
+                ObjectNameResolver.Add(scene.name, goPath, hash);
+                if (scene.name != "DontDestroyOnLoad" || SpecialCases.AllowedDontDestroyOnLoad(goPath))
+                {
+                    if (!ShouldSkipDumping(scene.name, goPath))
                     {
                         SaveTextureDump(scene, hash, dupe);
                     }
-                    SaveTextureByPath("Global", hash, dupe); // Also dump tk2ds in global
-                    GameObject.Destroy(dupe);
                 }
-                else
-                {
-                    // old style dump will dump with directory structure
-                    if (isMaterialUnprocessed)
-                    {
-                        var dupe = TextureUtils.duplicateTexture(tex);
-                        var hash = HashWithCache.getTk2dSpriteHash(tk2ds);
-                        MaterialProcessed[crc] = hash;
-                        SaveTextureByPath("Global", hash, dupe);
-                        GameObject.Destroy(dupe);
-                    }
-                    if (scene.name != "DontDestroyOnLoad" || SpecialCases.AllowedDontDestroyOnLoad(goPath))
-                    {
-                        SaveTextureDump(scene, baseName, tex);
-                    }
-                }
-
-
-
+                SaveTextureByPath("Global", hash, dupe); // Also dump tk2ds in global
+                GameObject.Destroy(dupe);
                 return;
             }
+        }
+
+        internal bool ShouldSkipDumping(string sceneName,string goPath)
+        {
+            if (ObjectNameResolver.Contains(sceneName, goPath))
+            {
+                var savedHash = ObjectNameResolver.GetHashFromPath($"{sceneName}/{goPath}");
+                string DUMP_DIR = Path.Combine(SkinManager.DATA_DIR, "Dump");
+                if (File.Exists(Path.Combine(DUMP_DIR, $"{sceneName}/{savedHash}.png")))
+                {
+                    Log($"Skipping already present in names.json : {goPath}");
+                    return true;
+                }
+            }
+            return false;
         }
 
         internal void updateDumpProgressText()
@@ -245,6 +234,13 @@ namespace CustomKnight
         {
             done = 0;
             detected = done;
+            string DUMP_DIR = Path.Combine(SkinManager.DATA_DIR, "Dump");
+
+            foreach (string path in Directory.GetDirectories(DUMP_DIR))
+            {
+                string directoryName = new DirectoryInfo(path).Name;
+                ObjectNameResolver.LoadNameDb(Path.Combine(path, "names.json"), directoryName);
+            }
             yield return new WaitForSecondsRealtime(1f);
             do
             {

--- a/CustomKnight/Skin/Swapper/HashCache.cs
+++ b/CustomKnight/Skin/Swapper/HashCache.cs
@@ -1,5 +1,5 @@
-using Newtonsoft.Json;
 using System.IO;
+using Newtonsoft.Json;
 
 namespace CustomKnight
 {

--- a/CustomKnight/Skin/Swapper/ObjectNameResolver.cs
+++ b/CustomKnight/Skin/Swapper/ObjectNameResolver.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using System.Linq;
+using System.Security.Policy;
 using static Satchel.IoUtils;
 
 namespace CustomKnight.Skin.Swapper
@@ -24,6 +25,10 @@ namespace CustomKnight.Skin.Swapper
             {
                 NameDb[sceneName][hash] = new List<string>();
             }
+        }
+        internal static bool Contains(string sceneName, string objectPath)
+        {
+            return GetPathsForScene(sceneName).Contains(objectPath);
         }
         internal static void Add(string sceneName, string objectPath, string hash)
         {

--- a/CustomKnight/Skin/Swapper/ObjectNameResolver.cs
+++ b/CustomKnight/Skin/Swapper/ObjectNameResolver.cs
@@ -102,11 +102,15 @@ namespace CustomKnight.Skin.Swapper
         internal static List<string> GetPathsForScene(string scn)
         {
             List<string> paths = new List<string>();
-            foreach (var hash in NameDb[scn])
+            if(NameDb.TryGetValue(scn,out var sceneDb))
             {
-                paths.AddRange(hash.Value);
+                foreach (var hash in sceneDb)
+                {
+                    paths.AddRange(hash.Value);
+                }
+                return paths;
             }
-            return paths;
+            return new List<string>(); 
         }
 
         internal static string GetHashFromPath(string hashPath)

--- a/CustomKnight/Skin/Swapper/ObjectNameResolver.cs
+++ b/CustomKnight/Skin/Swapper/ObjectNameResolver.cs
@@ -1,6 +1,5 @@
 ﻿using System.IO;
 using System.Linq;
-using System.Security.Policy;
 using static Satchel.IoUtils;
 
 namespace CustomKnight.Skin.Swapper
@@ -102,7 +101,7 @@ namespace CustomKnight.Skin.Swapper
         internal static List<string> GetPathsForScene(string scn)
         {
             List<string> paths = new List<string>();
-            if(NameDb.TryGetValue(scn,out var sceneDb))
+            if (NameDb.TryGetValue(scn, out var sceneDb))
             {
                 foreach (var hash in sceneDb)
                 {
@@ -110,7 +109,7 @@ namespace CustomKnight.Skin.Swapper
                 }
                 return paths;
             }
-            return new List<string>(); 
+            return new List<string>();
         }
 
         internal static string GetHashFromPath(string hashPath)

--- a/CustomKnight/Skin/Swapper/SpriteRendererMaterialPropertyBlock.cs
+++ b/CustomKnight/Skin/Swapper/SpriteRendererMaterialPropertyBlock.cs
@@ -8,14 +8,46 @@ namespace CustomKnight
     public class SpriteRendererMaterialPropertyBlock : MonoBehaviour
     {
 
+        /// <summary>
+        /// Replaces the Sprite by name instead of creating a MaterialPropertyBlock to replace the texture sheet
+        /// </summary>
+        public bool spriteReplaceMode = false;
+
         private MaterialPropertyBlock defaultPropertyBlock;
 
         private SpriteRenderer sr;
 
         private Dictionary<String, MaterialPropertyBlock> mpbs = new Dictionary<String, MaterialPropertyBlock>();
+        private Dictionary<String, Sprite> sprites = new Dictionary<String, Sprite>();
 
         private bool hasCustomDefault;
 
+
+        private void ReplaceSprite()
+        {
+            if (sr == null)
+            {
+                sr = GetComponent<SpriteRenderer>();
+            }
+            if (sprites.TryGetValue(sr.sprite.name, out var sprite))
+            {
+                sr.sprite = sprite;
+            }
+            else
+            {
+                var tex = CustomKnight.swapManager.GetTexture2D(gameObject.scene, sr.sprite.name);
+                if (tex != null)
+                {
+                    var pivot = new Vector2(0.5f, 0.5f);
+                    sprites[sr.sprite.name] = Sprite.Create(tex, new Rect(0, 0, tex.width, tex.height), pivot, sr.sprite.pixelsPerUnit);
+                    sr.sprite = sprites[sr.sprite.name];
+                }
+                else
+                {
+                    CustomKnight.Instance.Log($"[ReplaceSprite] Unknown Animated object:{name}:sprite:{sr.sprite.name}");
+                }
+            }
+        }
         private void UpdateMaterialPropertyBlock()
         {
             
@@ -38,6 +70,7 @@ namespace CustomKnight
                 var tex = CustomKnight.swapManager.GetTexture2D(gameObject.scene, sr.sprite.name);
                 if (tex != null)
                 {
+                   
                     AddSprite(sr.sprite.name, tex);
                     sr.SetPropertyBlock(mpbs[sr.sprite.name]);
                 }
@@ -84,8 +117,16 @@ namespace CustomKnight
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
         public void OnWillRenderObject()
         {
-            UpdateMaterialPropertyBlock();
+            if (spriteReplaceMode)
+            {
+                ReplaceSprite();
+            }
+            else
+            {
+                UpdateMaterialPropertyBlock();
+            }
         }
+
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 
     }

--- a/CustomKnight/Skin/Swapper/SpriteRendererMaterialPropertyBlock.cs
+++ b/CustomKnight/Skin/Swapper/SpriteRendererMaterialPropertyBlock.cs
@@ -29,15 +29,23 @@ namespace CustomKnight
                 sr.GetPropertyBlock(defaultPropertyBlock);
                 hasCustomDefault = false;
             }
-            if (mpbs != null)
+            if (mpbs.TryGetValue(sr.sprite.name, out var mpb))
             {
-
-                if (mpbs.TryGetValue(sr.sprite.name, out var mpb))
+                sr.SetPropertyBlock(mpb);
+            }
+            else
+            {
+                var tex = CustomKnight.swapManager.GetTexture2D(gameObject.scene, sr.sprite.name);
+                if (tex != null)
                 {
-                    sr.SetPropertyBlock(mpb);
+                    AddSprite(sr.sprite.name, tex);
+                    sr.SetPropertyBlock(mpbs[sr.sprite.name]);
                 }
-                else {
-                    if (!hasCustomDefault) { 
+                else
+                {
+
+                    if (!hasCustomDefault)
+                    {
                         CustomKnight.Instance.Log($"[UpdateMaterialPropertyBlock] Unknown Animated object:{name}:sprite:{sr.sprite.name}");
                     }
                     sr.SetPropertyBlock(defaultPropertyBlock);

--- a/CustomKnight/Skin/Swapper/SpriteRendererMaterialPropertyBlock.cs
+++ b/CustomKnight/Skin/Swapper/SpriteRendererMaterialPropertyBlock.cs
@@ -1,5 +1,3 @@
-using UnityEngine;
-
 namespace CustomKnight
 {
     /// <summary>
@@ -50,7 +48,7 @@ namespace CustomKnight
         }
         private void UpdateMaterialPropertyBlock()
         {
-            
+
             if (sr == null)
             {
                 sr = GetComponent<SpriteRenderer>();
@@ -70,7 +68,7 @@ namespace CustomKnight
                 var tex = CustomKnight.swapManager.GetTexture2D(gameObject.scene, sr.sprite.name);
                 if (tex != null)
                 {
-                   
+
                     AddSprite(sr.sprite.name, tex);
                     sr.SetPropertyBlock(mpbs[sr.sprite.name]);
                 }

--- a/CustomKnight/Skin/Swapper/SwapManager.cs
+++ b/CustomKnight/Skin/Swapper/SwapManager.cs
@@ -1,7 +1,9 @@
 using CustomKnight.Skin.Swapper;
+using System;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using UnityEngine;
 using static Satchel.IoUtils;
 
 namespace CustomKnight
@@ -186,6 +188,29 @@ namespace CustomKnight
                     HashWithCache.saveIfUpdated();
                 }
             }
+        }
+        internal Texture2D GetTexture2D(Scene scene, string spriteName)
+        {
+            if(!enabled) return null;
+            var path = Path.Combine("dndy_spr_anim", spriteName+".png");
+            return GetTexture2DDirect(Path.Combine(DATA_DIR, scene.name, path));
+        }
+        private Texture2D GetTexture2DDirect(string texturePath)
+        {
+            if (loadedTextures.TryGetValue(texturePath, out var tex))
+            {
+                return tex;
+            }
+            var texture = new Texture2D(2, 2);
+            if (File.Exists(texturePath))
+            {
+                byte[] buffer = File.ReadAllBytes(texturePath);
+                texture.LoadImage(buffer.ToArray(), true);
+                loadedTextures[texturePath] = texture;
+                return texture;
+            }
+            return null;
+
         }
         private void loadTexture(GameObjectProxy gop)
         {

--- a/CustomKnight/Skin/Swapper/SwapManager.cs
+++ b/CustomKnight/Skin/Swapper/SwapManager.cs
@@ -303,7 +303,7 @@ namespace CustomKnight
                         }
                         var behaviour = GO.GetAddComponent<SpriteRendererMaterialPropertyBlock>();
                         behaviour.SetDefault(tex);//todo somehow determine the sprite name and set the sprites instead
-                        
+                        behaviour.spriteReplaceMode = SpecialCases.ChildSpriteAnimatedByParent(goPath);
                         //GameObject.Destroy(anim);
                         //go.AddComponent<Animator>();
                         // destroyed the animation, possibly add satchel customAnimation later

--- a/CustomKnight/Skin/Swapper/SwapManager.cs
+++ b/CustomKnight/Skin/Swapper/SwapManager.cs
@@ -1,10 +1,7 @@
-using CustomKnight.Skin.Swapper;
-using System;
 using System.IO;
 using System.Linq;
-using System.Security.AccessControl;
 using System.Text.RegularExpressions;
-using UnityEngine;
+using CustomKnight.Skin.Swapper;
 using static Satchel.IoUtils;
 
 namespace CustomKnight
@@ -192,8 +189,8 @@ namespace CustomKnight
         }
         internal Texture2D GetTexture2D(Scene scene, string spriteName)
         {
-            if(!enabled) return null;
-            var path = Path.Combine("ck_spr_anim", spriteName+".png");
+            if (!enabled) return null;
+            var path = Path.Combine("ck_spr_anim", spriteName + ".png");
             return GetTexture2DDirect(Path.Combine(DATA_DIR, scene.name, path));
         }
         private Texture2D GetTexture2DDirect(string texturePath)
@@ -488,7 +485,8 @@ namespace CustomKnight
                 using (FileStream fs = File.Create(Path.Combine(pathToLoad, "replace.txt")))
                 {
                     //create and close the stream
-                };
+                }
+                ;
             }
             using (StreamReader reader = File.OpenText(Path.Combine(pathToLoad, "replace.txt")))
             {
@@ -588,7 +586,7 @@ namespace CustomKnight
                 {
                     this.Log($"[DisableDirectorySwaps] Skipping loading subdirectories in {directoryName}");
                 }
-                
+
                 Scenes[directoryName] = objects;
             }
             foreach (var hp in hashPaths)
@@ -668,10 +666,11 @@ namespace CustomKnight
             ReplaceCache = new Dictionary<string, List<string>>();
             nextCheck = INITAL_NEXT_CHECK;
 
-            if(!CustomKnight.GlobalSettings.DisableDirectorySwaps)
+            if (!CustomKnight.GlobalSettings.DisableDirectorySwaps)
             {
                 LoadSwapByPath(Path.Combine(SkinManager.DATA_DIR, SWAP_FOLDER)); // global strings and skins
-            } else
+            }
+            else
             {
                 this.Log("[DisableDirectorySwaps] Skipping Global Directory");
             }

--- a/CustomKnight/Skin/Swapper/SwapManager.cs
+++ b/CustomKnight/Skin/Swapper/SwapManager.cs
@@ -277,11 +277,8 @@ namespace CustomKnight
                             this.LogFine($"Animation  : {anim.name}");
                         }
                         var behaviour = GO.GetAddComponent<SpriteRendererMaterialPropertyBlock>();
-                        MaterialPropertyBlock block = new MaterialPropertyBlock();
-#pragma warning disable CS0618 // Type or member is obsolete
-                        block.AddTexture("_MainTex", tex);
-#pragma warning restore CS0618 // Type or member is obsolete
-                        behaviour.mpb = block;
+                        behaviour.SetDefault(tex);//todo somehow determine the sprite name and set the sprites instead
+                        
                         //GameObject.Destroy(anim);
                         //go.AddComponent<Animator>();
                         // destroyed the animation, possibly add satchel customAnimation later

--- a/CustomKnight/Skin/Swapper/SwapManager.cs
+++ b/CustomKnight/Skin/Swapper/SwapManager.cs
@@ -192,7 +192,7 @@ namespace CustomKnight
         internal Texture2D GetTexture2D(Scene scene, string spriteName)
         {
             if(!enabled) return null;
-            var path = Path.Combine("dndy_spr_anim", spriteName+".png");
+            var path = Path.Combine("ck_spr_anim", spriteName+".png");
             return GetTexture2DDirect(Path.Combine(DATA_DIR, scene.name, path));
         }
         private Texture2D GetTexture2DDirect(string texturePath)


### PR DESCRIPTION
- Kills directory style dumps 
- Skin authors can disable directory swaps by going into tools > disable directory swap to test their skins
- Improved speed when dumping names.json by resuming dumps. 
  - This skips existing files and names.json entries, authors must delete the folder to do a fresh dump,
- Animated sprites can be dumped (The frame you care about MUST show up visually for it to dump),
- Experimental animated sprite swapping can be done by modifiying the sprites in ck_spr_anim. 
  - Currently this only supports shade lord.
- Add support for displaying charms in some other places in the UI correctly,
- Support for grimm flame UI (regenerating default skin generates the files in charms/front.png or charms/back.png),
- Help text in pause menu advising about the keybind to toggle the menu
- Default particle swaps to enabled in this version